### PR TITLE
62 calculate commits per month

### DIFF
--- a/run
+++ b/run
@@ -13,7 +13,7 @@ if [ $# == 1 ]; then           # One command line argument
     echo "You chose test"
     # Call the test suite here
   else                    # URL_FILE
-    tsc                   # Compile TypeScript files to JavaScript
+    npx tsc                   # Compile TypeScript files to JavaScript
     if [ $? -ne 0 ]; then # ?
       echo "TypeScript compilation failed. Exiting..."
       exit 1

--- a/src/api_access.ts
+++ b/src/api_access.ts
@@ -13,7 +13,7 @@ async function fetchAllPages<T>(endpoint: string, params: any = {}): Promise<T[]
 }
 
 // Function to fetch the number of commits in a repository
-export async function fetchCommitCount(owner: string, repo: string): Promise<number> {
+async function fetchCommitCount(owner: string, repo: string): Promise<number> {
   try {
     // Fetch the first page with per_page set to 1 to minimize data transferred
     const response = await octokit.repos.listCommits({

--- a/src/api_access.ts
+++ b/src/api_access.ts
@@ -1,4 +1,4 @@
-import { Octokit, App } from "octokit";
+import { Octokit } from "@octokit/rest";
 import { Logger } from './logger.js'
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN; // for GitHub token: export GITHUB_TOKEN="your_token_here"
@@ -13,7 +13,7 @@ async function fetchAllPages<T>(endpoint: string, params: any = {}): Promise<T[]
 }
 
 // Function to fetch the number of commits in a repository
-async function fetchCommits(owner: string, repo: string): Promise<number> {
+export async function fetchCommitCount(owner: string, repo: string): Promise<number> {
   try {
     const commits = await octokit.paginate(octokit.repos.listCommits, {
       owner,
@@ -57,122 +57,165 @@ export async function checkLicense(desiredLicense: string, owner: string, name: 
 }
 
 // Function to fetch repository statistics
-export async function fetchRepoStats(owner: string, repo: string) {
-  try {
-    // Fetch issues
-    const openIssues = await fetchAllPages('GET /repos/{owner}/{repo}/issues', {
-      owner,
-      repo,
-      state: 'open',
-      per_page: 100
-    });
-    const closedIssues = await fetchAllPages('GET /repos/{owner}/{repo}/issues', {
-      owner,
-      repo,
-      state: 'closed',
-      per_page: 100
-    });
-    const totalOpenIssues = openIssues.filter((issue: any) => !issue.pull_request).length;
-    const totalClosedIssues = closedIssues.filter((issue: any) => !issue.pull_request).length;
-    const issueRatio = totalOpenIssues > 0 ? (totalClosedIssues / totalOpenIssues).toFixed(2) : 'N/A';
+export class RepoStats {
+  owner: string;
+  repo: string;
+  totalOpenIssues: number;
+  totalClosedIssues: number;
+  issueRatio: string;
+  totalMergedPullRequests: number;
+  totalOpenPullRequests: number;
+  totalClosedPullRequests: number;
+  pullRequestRatio: string;
+  totalForks: number;
+  totalComments: number;
+  commentFrequency: string;
+  totalContributors: number;
+  licenseName: number | undefined;
+  readmeLength: number;
+  daysActive: number;
+  firstCommitDate: Date;
+  lastCommitDate: Date;
+  totalCommits: number;
 
-    // Fetch pull requests
-    const openPullRequests = await fetchAllPages('GET /repos/{owner}/{repo}/pulls', {
-      owner,
-      repo,
-      state: 'open',
-      per_page: 100
-    });
-    const closedPullRequests = await fetchAllPages('GET /repos/{owner}/{repo}/pulls', {
-      owner,
-      repo,
-      state: 'closed',
-      per_page: 100
-    });
-    const totalMergedPullRequests = closedPullRequests.filter((pr: any) => pr.merged_at).length;
-    const totalOpenPullRequests = openPullRequests.length;
-    const totalClosedPullRequests = closedPullRequests.length;
-    const pullRequestRatio = totalOpenPullRequests > 0 ? (totalClosedPullRequests / totalOpenPullRequests).toFixed(2) : 'N/A';
+  constructor(owner: string, repo: string) {
+    this.owner = owner;
+    this.repo = repo;
+    // Initialize properties with default values
+    this.totalOpenIssues = 0;
+    this.totalClosedIssues = 0;
+    this.issueRatio = 'N/A';
+    this.totalMergedPullRequests = 0;
+    this.totalOpenPullRequests = 0;
+    this.totalClosedPullRequests = 0;
+    this.pullRequestRatio = 'N/A';
+    this.totalForks = 0;
+    this.totalComments = 0;
+    this.commentFrequency = 'N/A';
+    this.totalContributors = 0;
+    this.licenseName = 0;
+    this.readmeLength = 0;
+    this.daysActive = 0;
+    this.firstCommitDate = new Date();
+    this.lastCommitDate = new Date();
+    this.totalCommits = 0;
+  }
 
-    // Fetch repository metadata (includes forks, comments, etc.)
-    const { data: repoData } = await octokit.repos.get({
-      owner,
-      repo
-    });
-    const totalForks = repoData.forks_count;
+  async fetchData() {
+    try {
+      // Fetch issues
+      const openIssues = await fetchAllPages('GET /repos/{owner}/{repo}/issues', {
+        owner: this.owner,
+        repo: this.repo,
+        state: 'open',
+        per_page: 100
+      });
+      const closedIssues = await fetchAllPages('GET /repos/{owner}/{repo}/issues', {
+        owner: this.owner,
+        repo: this.repo,
+        state: 'closed',
+        per_page: 100
+      });
+      this.totalOpenIssues = openIssues.filter((issue: any) => !issue.pull_request).length;
+      this.totalClosedIssues = closedIssues.filter((issue: any) => !issue.pull_request).length;
+      this.issueRatio = this.totalOpenIssues > 0 ? (this.totalClosedIssues / this.totalOpenIssues).toFixed(2) : 'N/A';
 
-    // Fetch comments
-    const issueComments = await fetchAllPages('GET /repos/{owner}/{repo}/issues/comments', {
-      owner,
-      repo,
-      per_page: 100
-    });
-    const pullRequestComments = await fetchAllPages('GET /repos/{owner}/{repo}/pulls/comments', {
-      owner,
-      repo,
-      per_page: 100
-    });
-    const totalComments = issueComments.length + pullRequestComments.length;
+      // Fetch pull requests
+      const openPullRequests = await fetchAllPages('GET /repos/{owner}/{repo}/pulls', {
+        owner: this.owner,
+        repo: this.repo,
+        state: 'open',
+        per_page: 100
+      });
+      const closedPullRequests = await fetchAllPages('GET /repos/{owner}/{repo}/pulls', {
+        owner: this.owner,
+        repo: this.repo,
+        state: 'closed',
+        per_page: 100
+      });
+      this.totalMergedPullRequests = closedPullRequests.filter((pr: any) => pr.merged_at).length;
+      this.totalOpenPullRequests = openPullRequests.length;
+      this.totalClosedPullRequests = closedPullRequests.length;
+      this.pullRequestRatio = this.totalOpenPullRequests > 0 ? (this.totalClosedPullRequests / this.totalOpenPullRequests).toFixed(2) : 'N/A';
 
-    // Calculate comment frequency
-    const totalCommits = await fetchCommits(owner, repo); // Fetch total commits
-    const commentFrequency = (totalCommits + totalOpenIssues + totalClosedIssues) > 0
-      ? (totalComments / (totalCommits + totalOpenIssues + totalClosedIssues)).toFixed(2)
-      : 'N/A';
+      // Fetch repository metadata
+      const { data: repoData } = await octokit.repos.get({
+        owner: this.owner,
+        repo: this.repo
+      });
+      this.totalForks = repoData.forks_count;
 
-    // fetch the number of contributors
-    const contributors = await fetchAllPages('GET /repos/{owner}/{repo}/contributors', {
-      owner,
-      repo,
-      per_page: 100
-    });
-    const totalContributors = contributors.length;
+      // Fetch comments
+      const issueComments = await fetchAllPages('GET /repos/{owner}/{repo}/issues/comments', {
+        owner: this.owner,
+        repo: this.repo,
+        per_page: 100
+      });
+      const pullRequestComments = await fetchAllPages('GET /repos/{owner}/{repo}/pulls/comments', {
+        owner: this.owner,
+        repo: this.repo,
+        per_page: 100
+      });
+      this.totalComments = issueComments.length + pullRequestComments.length;
 
-    // License
-    const licenseName = await checkLicense("MIT License", owner, repo);
+      // Calculate comment frequency
+      this.totalCommits = await fetchCommitCount(this.owner, this.repo); // Fetch total commits
+      this.commentFrequency = (this.totalCommits + this.totalOpenIssues + this.totalClosedIssues) > 0
+        ? (this.totalComments / (this.totalCommits + this.totalOpenIssues + this.totalClosedIssues)).toFixed(2)
+        : 'N/A';
 
-    // fetch the README file length in characters
-    const readme = await octokit.repos.getReadme({ owner, repo });
-    const readmeLength = Buffer.from(readme.data.content, 'base64').toString('utf-8').length;
+      // Fetch the number of contributors
+      const contributors = await fetchAllPages('GET /repos/{owner}/{repo}/contributors', {
+        owner: this.owner,
+        repo: this.repo,
+        per_page: 100
+      });
+      this.totalContributors = contributors.length;
 
+      // License
+      this.licenseName = await checkLicense("MIT License", this.owner, this.repo);
 
-    // fetch the working life of the repository in days
-    const created = new Date(repoData.created_at);
-    const updated = new Date(repoData.updated_at);
-    const daysActive = Math.ceil((updated.getTime() - created.getTime()) / (1000 * 3600 * 24));
+      // Fetch the README file length
+      const readme = await octokit.repos.getReadme({ owner: this.owner, repo: this.repo });
+      this.readmeLength = Buffer.from(readme.data.content, 'base64').toString('utf-8').length;
 
-    
-    // fetch the date of the first commit
-    const firstCommit = await octokit.repos.listCommits({ owner, repo, per_page: 100 });
-    const firstCommitDate = firstCommit.data[0]?.commit?.author?.date ? new Date(firstCommit.data[0].commit.author.date) : new Date();
-    // fetch the date of the last commit
-    const lastCommit = await octokit.repos.listCommits({ owner, repo, per_page: 100 });
-    const lastCommitDate = lastCommit.data[0]?.commit?.author?.date ? new Date(lastCommit.data[0].commit.author.date) : new Date();
+      // Fetch the working life of the repository in days
+      const created = new Date(repoData.created_at);
+      const updated = new Date(repoData.updated_at);
+      this.daysActive = Math.ceil((updated.getTime() - created.getTime()) / (1000 * 3600 * 24));
 
-    // Output the results
-    console.log('Total Commits:', totalCommits);
-    console.log(`Total Open Issues: ${totalOpenIssues}`);
-    console.log(`Total Closed Issues: ${totalClosedIssues}`);
-    console.log(`Ratio of Closed/Open Issues: ${issueRatio}`);
-    console.log(`Total Open Pull Requests: ${totalOpenPullRequests}`);
-    console.log(`Total Closed Pull Requests: ${totalClosedPullRequests}`);
-    console.log(`Total Merged Pull Requests: ${totalMergedPullRequests}`);
-    console.log(`Ratio of Closed/Open Pull Requests: ${pullRequestRatio}`);
-    console.log(`Total Forks: ${totalForks}`);
-    console.log(`Total Comments: ${totalComments}`);
-    console.log(`Comment Frequency: ${commentFrequency}`);
-    console.log(`Total Contributors: ${totalContributors}`);
-    console.log(`License: ${licenseName}`); 
-    console.log(`README Length: ${readmeLength} characters`);
-    console.log(`Days Active: ${daysActive}`);
-    console.log(`First Commit Date: ${firstCommitDate}`);
-    console.log(`Last Commit Date: ${lastCommitDate}`);
-    
-    
-  } catch (error) {
-    handleError(error);
+      // Fetch the date of the first and last commit
+      const firstCommit = await octokit.repos.listCommits({ owner: this.owner, repo: this.repo, per_page: 100 });
+      this.firstCommitDate = firstCommit.data[0]?.commit?.author?.date ? new Date(firstCommit.data[0].commit.author.date) : new Date();
+      const lastCommit = await octokit.repos.listCommits({ owner: this.owner, repo: this.repo, per_page: 100 });
+      this.lastCommitDate = lastCommit.data[0]?.commit?.author?.date ? new Date(lastCommit.data[0].commit.author.date) : new Date();
+
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  displayStats() {
+    console.log('Total Commits:', this.totalCommits);
+    console.log(`Total Open Issues: ${this.totalOpenIssues}`);
+    console.log(`Total Closed Issues: ${this.totalClosedIssues}`);
+    console.log(`Ratio of Closed/Open Issues: ${this.issueRatio}`);
+    console.log(`Total Open Pull Requests: ${this.totalOpenPullRequests}`);
+    console.log(`Total Closed Pull Requests: ${this.totalClosedPullRequests}`);
+    console.log(`Total Merged Pull Requests: ${this.totalMergedPullRequests}`);
+    console.log(`Ratio of Closed/Open Pull Requests: ${this.pullRequestRatio}`);
+    console.log(`Total Forks: ${this.totalForks}`);
+    console.log(`Total Comments: ${this.totalComments}`);
+    console.log(`Comment Frequency: ${this.commentFrequency}`);
+    console.log(`Total Contributors: ${this.totalContributors}`);
+    console.log(`License: ${this.licenseName}`);
+    console.log(`README Length: ${this.readmeLength} characters`);
+    console.log(`Days Active: ${this.daysActive}`);
+    console.log(`First Commit Date: ${this.firstCommitDate}`);
+    console.log(`Last Commit Date: ${this.lastCommitDate}`);
   }
 }
+
 
 // Helper function to handle errors
 function handleError(error: any): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { RepositoryUrlData, UrlFileParser } from './urlFileParser.js'; // interface, class
 import { Repository } from './repository.js'  // class
 import { writeOutput } from './output.js'     // function
+import { RepoStats } from './api_access.js'
 
 export class Main {
   readonly urlFileParser: UrlFileParser;
@@ -34,16 +35,17 @@ var repositories: Repository[] = [];
 // Set the correct url, owner, and name for each repository
 var urlDataIndex: number;
 for (urlDataIndex = 0; urlDataIndex < urlData.length; urlDataIndex++) {
-  var newRepository = new Repository( urlData[urlDataIndex].url, 
-                                      urlData[urlDataIndex].owner, 
-                                      urlData[urlDataIndex].name
-                                    );
-  await newRepository.calculateAllMetrics();
+  var newRepository = new Repository( 
+    urlData[urlDataIndex].url, 
+    urlData[urlDataIndex].owner, 
+    urlData[urlDataIndex].name
+  );
+  //calculate metrics here
+  var repoInfo = new RepoStats(newRepository.owner,newRepository.name);
+  await newRepository.calculateAllMetrics(repoInfo);
   repositories.push(newRepository);
 }
-
 // Print out metric calculation results in NDJSON
-// As of now, there aren't any calculations being done, defaults are printed
 var repositoryIndex: number;
 var output: string = "";
 for (repositoryIndex = 0; repositoryIndex < repositories.length; repositoryIndex++) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,8 @@ for (urlDataIndex = 0; urlDataIndex < urlData.length; urlDataIndex++) {
   );
   //calculate metrics here
   var repoInfo = new RepoStats(newRepository.owner,newRepository.name);
+  await repoInfo.fetchTotalCommits();
+  await repoInfo.fetchRepoData();
   await newRepository.calculateAllMetrics(repoInfo);
   repositories.push(newRepository);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ for (urlDataIndex = 0; urlDataIndex < urlData.length; urlDataIndex++) {
   var repoInfo = new RepoStats(newRepository.owner,newRepository.name);
   await repoInfo.fetchTotalCommits();
   await repoInfo.fetchRepoData();
+  //await repoInfo.fetchData();
   await newRepository.calculateAllMetrics(repoInfo);
   repositories.push(newRepository);
 }

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -136,7 +136,7 @@ export class ResponsiveMaintainer extends Metric {
   }
   CalculateValue(totalCommits:number, daysActive:number): number {
     var months = daysActive/30;
-    return totalCommits/months;
+    return this.minMax(totalCommits/months,50,0); //arbitrary max and min values picked.
   }
 }
 

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -136,7 +136,7 @@ export class ResponsiveMaintainer extends Metric {
   }
   CalculateValue(totalCommits:number, daysActive:number): number {
     var months = daysActive/30;
-    return this.minMax(totalCommits/months,50,0); //arbitrary max and min values picked.
+    return this.minMax(totalCommits/months,100,0); //arbitrary max and min values picked.
   }
 }
 

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -131,9 +131,12 @@ export class ResponsiveMaintainer extends Metric {
     this.name = "ResponsiveMaintainer";
     this.value = 0;
   }
-
-  calculateValue(): number {
+  calculateValue():number{
     return 0;
+  }
+  CalculateValue(totalCommits:number, daysActive:number): number {
+    var months = daysActive/30;
+    return totalCommits/months;
   }
 }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -30,13 +30,13 @@ export class Repository {
   }
 
   async calculateAllMetrics() {
-    this.url.calculateValue();
-    await this.netScore.calculateValue();
-    this.rampUp.calculateValue();
-    this.correctness.calculateValue();
-    this.busFactor.calculateValue();
-    this.responsiveMaintainer.calculateValue();
-    this.license.calculateValue();
+    this.url.value = this.url.calculateValue();
+    this.netScore.value = await this.netScore.calculateValue();
+    this.rampUp.value = this.rampUp.calculateValue();
+    this.correctness.value = this.correctness.calculateValue();
+    this.busFactor.value = this.busFactor.calculateValue();
+    this.responsiveMaintainer.value = this.responsiveMaintainer.calculateValue();
+    this.license.value = this.license.calculateValue();
   }
 
   // This could be cleaned up but it works for now

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,6 +1,6 @@
 import { Url, NetScore, RampUp, Correctness, BusFactor, ResponsiveMaintainer, License} from './metric.js'
 import { writeOutput } from './output.js'
-
+import { RepoStats } from './api_access.js'
 export class Repository {
   owner: string;  // GitHub username of repository owner
   name: string;   // Name of the repository
@@ -29,13 +29,14 @@ export class Repository {
     this.license = new License(owner, name);
   }
 
-  async calculateAllMetrics() {
-    this.url.value = this.url.calculateValue();
-    this.netScore.value = await this.netScore.calculateValue();
+  async calculateAllMetrics(repoInfo: RepoStats) {
+    //Do we need to calculate this again???
+    //this.url.value = this.url.calculateValue(); 
+    //this.netScore.value = await this.netScore.calculateValue();
     this.rampUp.value = this.rampUp.calculateValue();
     this.correctness.value = this.correctness.calculateValue();
     this.busFactor.value = this.busFactor.calculateValue();
-    this.responsiveMaintainer.value = this.responsiveMaintainer.calculateValue();
+    this.responsiveMaintainer.value = this.responsiveMaintainer.CalculateValue(repoInfo.totalCommits, repoInfo.daysActive);
     this.license.value = this.license.calculateValue();
   }
 


### PR DESCRIPTION
Attempted to consolidate the fetches from the API into a more centralized spot. The FetchRepoStats method has been turned into a class for the information it grabs to be used. The CalculateAllMetrics method now takes this RepoStats class and distributes the necessary information to the individual metric calculation methods. The ResponsiveMaintainer is currently calculated by the total number of commits divided by the total months the repo has been open. Normalized between 100 and 0, which is just arbitrary values.